### PR TITLE
Bump runtime to 42

### DIFF
--- a/com.gitlab.adnan338.Nixwriter.yaml
+++ b/com.gitlab.adnan338.Nixwriter.yaml
@@ -1,6 +1,6 @@
 id: com.gitlab.adnan338.Nixwriter
 runtime: org.gnome.Platform
-runtime-version: "3.38"
+runtime-version: "42"
 sdk: org.gnome.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
@@ -35,5 +35,4 @@ modules:
       - install -Dm755 target/release/nixwriter --target-directory=/app/bin
       - install -Dm644 resources/com.gitlab.adnan338.Nixwriter.desktop --target-directory=/app/share/applications
       - install -Dm644 resources/com.gitlab.adnan338.Nixwriter.svg --target-directory=/app/share/icons/hicolor/scalable/apps
-      - install -Dm644 resources/com.gitlab.adnan338.Nixwriter.128x128.svg --target-directory=/app/share/icons/hicolor/128x128/apps/
       - install -Dm644 resources/com.gitlab.adnan338.Nixwriter.metainfo.xml --target-directory=/app/share/metainfo


### PR DESCRIPTION
Appstream can covert the svg to 64px and 128px icons.

Ping @adnan449, please review when you have time, thanks! 